### PR TITLE
update bip0039

### DIFF
--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [dependencies]
 aes = "0.7"
 bitvec = "1"
-bip0039 = { version = "0.9", features = ["std", "all-languages"] }
+bip0039 = { version = "0.11.0", features = ["std", "all-languages"] }
 blake2b_simd = "1"
 blake2s_simd = "1"
 blstrs = { version = "0.6.0", features = ["__private_bench"] }


### PR DESCRIPTION
Resolves dependency conflicts with downstream consumers of librustzcash->ironfish-rust